### PR TITLE
Prevent auto-acceptance of removing someone else from a fellowship.

### DIFF
--- a/MQ2AutoAccept.cpp
+++ b/MQ2AutoAccept.cpp
@@ -700,6 +700,10 @@ PLUGIN_API void OnPulse()
 				WriteChatf("\agMQ2AutoAccept :: Accepting self anchor portal cast\ax");
 				WinClick(FindMQ2Window("ConfirmationDialogBox"), "Yes_Button", "leftmouseup", 1);
 			}
+			else if (ci_find_substr(windowText, "Remove") != -1 || ci_find_substr(windowText, "from the fellowship") != -1) {
+				// Remove someone from fellowship.
+				// DebugSpew("\agMQ2AutoAccept :: Ignoring removal from fellowship\ax");
+			}
 			//none of the above? do we have any names
 			else if (!vNames.empty()) {
 				// All other confirmation boxes


### PR DESCRIPTION
Prevents MQ2AutoAccept from auto-accepting the confirmation when removing someone from a fellowship.

Clicking [Remove] in the fellowship window results in a confirmation, which MQ2AutoAccept instantly and automatically accepts.

This does not seem an appropriate location for auto-accept to act upon as there is no automation that initiated, nor useful to a remote character.